### PR TITLE
Remove mapping for /dtp/ which should be in WordPress.

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1880,7 +1880,6 @@ _/bumobile phpbin ;
   _/dos/facebook content ;  # 
   _/double-it content ;  # top-level
   _/dlanglai content ;  # top-level
-  _/dtp content ;  # top-level
   _/dsgsupport content ;  # top-level
   _/dsg content ;  # top-level
   _/ds-biolobby content ;  # top-level


### PR DESCRIPTION
This contains one change to prod sites.map for INC12445531