### PR TITLE
Add static sub-directory underneath a WP site

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1300,6 +1300,7 @@ _/bumobile phpbin ;
   _/globaloperations content ;  # top-level
   _/globalmfg content ;  # top-level
   _/globalmediakit content ;  # top-level
+  _/globalprograms/wp-assets content;
   _/global-crisis content ;  # top-level
   _/gpmm content ;  # top-level
   _/gpts/wp-assets content ;  # 


### PR DESCRIPTION
Necessary so a micro-site underneath this WP site is accessible.