### PR TITLE
Point all of bu.edu/globaldaysofservice to content

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1293,7 +1293,7 @@ _/bumobile phpbin ;
   # _/globalprograms content ;  # 2018-06-04 resync
   _/globalfuture content ;  # top-level
   _/glc content ;  # top-level
-  _/globaldaysofservice/logyourhours content ;  # 
+  _/globaldaysofservice content ;  # 
   _/glacier content ;  # top-level
   _/globe content ;  # top-level
   _/globalhouse content ;  # top-level


### PR DESCRIPTION
bu.edu/globaldaysofservice currently points at the WP backends and returns a 404, the whole path should route to the content backends not just the micro-site bu.edu/globaldaysofservice/logyourhours