### PR TITLE
Move /preview homepage to S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@
 #FROM buist/websites-webrouter-base:2018.04.23
 #FROM buist/websites-webrouter-base:2018.06.04
 #FROM buist/websites-webrouter-base:2018.06.07
-FROM buist/websites-webrouter-base:2018.06.11
+#FROM buist/websites-webrouter-base:2018.06.11
+FROM buist/websites-webrouter-base:2018.07.11
 
 # for now this is our split and everything below this is for a different location
 #

--- a/landscape/prod/hosts.map.erb
+++ b/landscape/prod/hosts.map.erb
@@ -29,3 +29,15 @@ uiscgi_content <%= ENV['BACKEND_UISCGI_CONTENT'] || "ist-uiscgi-content-#{ENV['L
 # app-rewrite backend to make certain that the /apps-rewrite is on the path
 # #
 apps-rewrite <%= ENV['BACKEND_PHPBIN'] || "ist-web-phpbin-#{ENV['LANDSCAPE']}.bu.edu" %>/apps-rewrite ;
+
+# ###
+# The following backend types provide the homepage in S3.
+# There are multiple entries because the the homepage needs to map to
+# a subdirectory on the S3 bucket.
+#
+# This aws_homepage bucket is used for everything that maps normally:
+aws_home buaws-websites-homepage-prod.s3-website-us-east-1.amazonaws.com ;
+
+# These entries are necessary to map to specific URLs in the /home space:
+#
+aws_home_index buaws-websites-homepage-prod.s3-website-us-east-1.amazonaws.com/home/index.html ;

--- a/landscape/prod/maps/backend_hostheader.map
+++ b/landscape/prod/maps/backend_hostheader.map
@@ -1,0 +1,25 @@
+# The values in this file override the default host header which is the Host header that NGINX received ($host).
+#
+# There should be very few entries in this file as the default works well for most things.
+#
+# Most entries in this file will be of form:
+#
+# backend_name $backend_hostname ;
+#
+# This will set the header to the backend/upstream hostname.  This is necessary for all
+# S3 buckets.
+#
+s3bucket $backend_hostname ;
+
+# This test entry is to a fixed value to simplify the test scripts
+checkhostheader hostheader.bu.edu ;
+
+#checkhostheader $backend_hostname ;
+
+# There are 3 backend types for the homepage in S3.
+#
+# The normal bucket
+aws_home $backend_hostname ;
+
+# These backends map to specific URLs and need to be hardcoded
+aws_home_index buaws-websites-homepage-prod.s3-website-us-east-1.amazonaws.com ;

--- a/landscape/prod/maps/backend_scheme.map
+++ b/landscape/prod/maps/backend_scheme.map
@@ -1,0 +1,19 @@
+# This map determines what scheme to use for the upstream request.  Most
+# backends support both http and https but some backends (for example S3 buckets)
+# only support http.  The default is $scheme and the external file backend_scheme.map
+# allows the forcing of the backend.
+#
+# Most entries will be of form:
+#
+# backend_name http ;
+#
+# This will cause the backend to only do http even if the original client request was through https.  Note
+# that this only determines the scheme but the X-Method variables will be based on the original client connection.
+#
+
+# Home Page backends
+aws_home http ;
+aws_home_index http ;
+
+# This test entry is to a fixed value to simplify the test scripts
+checkhostheader http ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1542,7 +1542,7 @@ _/bumobile phpbin ;
   _/projects content ;  # top-level
   _/prs content ;  # top-level
   _/premed content ;  # top-level
-  _/preview content ;  # top-level
+  _/preview aws_home ;  # top-level
   _/prevmedresidency content ;  # top-level
   _/procurement content ;  # top-level
   _/playground content ;  # top-level


### PR DESCRIPTION
The goal of this pull request is to do the bulk of the work to support the home page being in S3.  This is similar to how we approached the www-test.bu.edu transition where /preview was using the S3 bucket while the active homepage had not changed.

Once this is in place we will be able to switch the home page by:

_/index.html aws_home_index ;
_/home aws_home ;