### PR TITLE
Move homepage to S3

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -901,7 +901,7 @@ _/bumobile phpbin ;
   _/hoarding content ;  # top-level
   _/hockeygolf content ;  # top-level
   _/homepage content ;  # top-level
-  _/home content ;  # top-level
+  _/home aws_home ;  # top-level
   _/holmul content ;  # top-level
   _/honordeanmeenan content ;  # top-level
   _/homecoming content ;  # top-level
@@ -943,7 +943,7 @@ _/bumobile phpbin ;
   _/interv content ;  # top-level
   _/index2.html content ;  # top-level
   _/investigate content ;  # top-level
-  _/index.html content ;  # top-level
+  _/index.html aws_home_index ;  # top-level
   _/integratedmed content ;  # top-level
   _/inaugural content ;  # top-level
   _/info/downloads content ;  # 


### PR DESCRIPTION
This change moves the homepage (/index.html) and it's supporting files (/home) to AWS.  It can be backed out by switching both entries back to content.