### PR TITLE
Update routing to use new content backends

### DIFF
--- a/landscape/prod/hosts.map.erb
+++ b/landscape/prod/hosts.map.erb
@@ -1,14 +1,14 @@
 legacy <%= ENV['BACKEND_WEB_LEGACY'] || "ist-web-legacy-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 # these are the old content servers using buapache configuration
-content <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-nocache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-cache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+oldcontent <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+oldcontent-nocache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+oldcontent-cache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 # these are the new content servers built as part of the Weblogin retirement project
-#content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-#content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-#content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 wpassets <%= ENV['BACKEND_WP_CONTENT'] || "ist-wp-assets-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 

--- a/landscape/prod/hosts.map.erb
+++ b/landscape/prod/hosts.map.erb
@@ -1,14 +1,9 @@
 legacy <%= ENV['BACKEND_WEB_LEGACY'] || "ist-web-legacy-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
-# these are the old content servers using buapache configuration
-content <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-nocache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-cache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-
 # these are the new content servers built as part of the Weblogin retirement project
-#content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-#content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-#content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 wpassets <%= ENV['BACKEND_WP_CONTENT'] || "ist-wp-assets-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 

--- a/landscape/prod/hosts.map.erb
+++ b/landscape/prod/hosts.map.erb
@@ -1,9 +1,14 @@
 legacy <%= ENV['BACKEND_WEB_LEGACY'] || "ist-web-legacy-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
+# these are the old content servers using buapache configuration
+content <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-nocache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+content-cache <%= ENV['BACKEND_WEB_OLDCONTENT'] || "ist-web-oldcontent-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+
 # these are the new content servers built as part of the Weblogin retirement project
-content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
-content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+#content <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+#content-nocache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+#content-cache <%= ENV['BACKEND_WEB_CONTENT'] || "ist-web-content-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
 wpassets <%= ENV['BACKEND_WP_CONTENT'] || "ist-wp-assets-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 

--- a/landscape/prod/maps/cachecontrol.map
+++ b/landscape/prod/maps/cachecontrol.map
@@ -6,8 +6,9 @@
   django "no-cache, no-store" ;
   content-nocache "no-cache, no-store" ;
   # non-WordPress static content can not be
-  # cached because Weblogin does not set the 
+  # cached because Weblogin does not set the
   # no-cache header on protected content.
   content "no-cache, no-store" ;
+  oldcontent "no-cache, no-store" ;
 
   apps-rewrite "no-cache, no-store" ;


### PR DESCRIPTION
Rename old content backends and activate new content backends by un-commenting them.

RFC# CHG041307

Target deployment date is 8/16/18 at 5AM. 