### PR TITLE
Undo dnamixtures change

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -709,6 +709,7 @@ _/dje content ;
 _/dlanglai content ;
 _/dme content ;
 _/dna content ;
+_/dnamixtures/uploads content ;
 _/dos-test content ;
 _/dos/facebook content ;
 _/dos/lulingzi content ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -709,8 +709,6 @@ _/dje content ;
 _/dlanglai content ;
 _/dme content ;
 _/dna content ;
-_/dnamixtures/uploads content ;
-_/dnamixtures/static content ;
 _/dos-test content ;
 _/dos/facebook content ;
 _/dos/lulingzi content ;


### PR DESCRIPTION
Partially revert 5260d7f and 4432dd2: do not serve dnamixtures/static from content backend (but keep dnamixtures/uploads)