### PR TITLE
Take /tdl out of static sites list

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1887,7 +1887,6 @@ _/tanglewood content ;
 _/tanglewoodtwo content ;
 _/tbergend content ;
 _/tcp content ;
-_/tdl content ;
 _/tech-backup content ;
 _/tech-copy content ;
 _/tech-links content ;


### PR DESCRIPTION
/tdl has to be a wordpress site per INC12593344