### PR TITLE
Set no-cache for wpassets (WordPress /files content)

### DIFF
--- a/landscape/prod/maps/cachecontrol.map
+++ b/landscape/prod/maps/cachecontrol.map
@@ -11,4 +11,8 @@
   content "no-cache, no-store" ;
   oldcontent "no-cache, no-store" ;
 
+  # Same story for WordPress content on the
+  # wpassets server:
+  wpassets "no-cache, no-store" ;
+
   apps-rewrite "no-cache, no-store" ;


### PR DESCRIPTION
Legacy WebLogin doesn't set cache-control headers, so CloudFront will cache WebLogin-protected assets.