### PR TITLE
Create new /av/ route for non-WordPress media

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1696,6 +1696,7 @@ _/research/spotlight content ;
 _/research/wp-assets content ;
 _/research/xml content ;
 _/researchcommittees content ;
+_/researchsupport/av content ;
 _/resilience content ;
 _/resnet content ;
 _/resources content ;


### PR DESCRIPTION
Creating AV route for new directory with "Camtasia/mp4 files and additional interactivity; needs to be saved as mp4 with screencast."