### PR TITLE
Redirect several /av/ sites that are now being migrated.

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -252,7 +252,13 @@ _/auctions content ;
 _/auth-test content ; #top-level for authentication load test
 _/aux content ;
 _/av content ;
+_/av/abroad wordpress ;
 _/av/cader wordpress ;
+_/av/chapel wordpress ;
+_/av/disted wordpress ;
+_/av/globalprograms wordpress ;
+_/av/isso wordpress ;
+_/av/tech wordpress ;
 _/avl content ;
 _/avtonkov-today2 content ;
 _/awrecentgrads content ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -253,7 +253,9 @@ _/auth-test content ; #top-level for authentication load test
 _/aux content ;
 _/av content ;
 _/av/abroad wordpress ;
+_/av/asllrp wordpress ;
 _/av/cader wordpress ;
+_/av/celop wordpress ;
 _/av/chapel wordpress ;
 _/av/disted wordpress ;
 _/av/globalprograms wordpress ;


### PR DESCRIPTION
These should correspond to the specific directories being redirected at http://www.bu.edu/wp-admin/network/admin.php?page=bu-cms-redirect