### PR TITLE
Map /globalprograms/av to be accessible outside WP

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -969,6 +969,7 @@ _/globalmediakit content ;
 _/globalmfg content ;
 _/globaloperations content ;
 _/globalprograms/wp-assets content;
+_/globalprograms/av content;
 _/globalquestionnaire content ;
 _/globe content ;
 _/gms content ;


### PR DESCRIPTION
Adding entry for "_/globalprograms/av content;" so av files accessible outside WordPress after AV file migrations.