### PR TITLE
remove unused Primo content route

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1244,7 +1244,6 @@ _/libdb-tst content ;
 _/liberalstudies content ;
 _/libfiles content ;
 _/library-workflow content ;
-_/library/primo content ;
 _/library/wp-assets content ;
 _/life content ;
 _/lifebook content ;


### PR DESCRIPTION
BU Library is not longer maintaining a microsite at bu.edu/libary/primo/ so this removes that.