### PR TITLE
INC12665441 re-mount old av content here

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1339,6 +1339,7 @@ _/medfellowship content ;
 _/mediaguidebook content ;
 _/mediatoday content ;
 _/medicine content ;
+_/medicine/av content ;
 _/medlibstaff content ;
 _/medschool content ;
 _/medschoolgradprograms content ;


### PR DESCRIPTION
This rule does in effect duplicate the pre-existing parent rule but as it seems likely bu.edu/medicine may one day stop routing to the static content backends it's preferable to have a more specific route for the av content to continue routing to the static content backends.