### PR TITLE
accreditation-to-wordpress

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -155,7 +155,6 @@ _/abroadatbu content ;
 _/academics-archive content ;
 _/academics/archive content ;
 _/academy content ;
-_/accreditation content ;
 _/aclonline content ;
 _/acor content ;
 _/acoustics content ;


### PR DESCRIPTION
This removes the 'content' designation for Accreditation website, being re-launched now in WP from old static site previously.