### PR TITLE
moving postdocs site to WP

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1605,7 +1605,6 @@ _/pocketmba content ;
 _/polymer content ;
 _/porco content ;
 _/posenprogram content ;
-_/postdocs content ;
 _/practice content ;
 _/practicemanagement content ;
 _/precisiondx content ;


### PR DESCRIPTION
removing the content directive to /postdocs so the site will natively serve from WordPress (replacing an old-school index.asis redirect)