### PR TITLE
INC12696794

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1463,7 +1463,6 @@ _/myprint content ;
 _/mzank content ;
 _/naeser content ;
 _/naitest content ;
-_/nano content ;
 _/nanoheat content ;
 _/narrative content ;
 _/nassr-2013/wp-assets content ;


### PR DESCRIPTION
Remove /nano from maps, so it goes directly to WordPress