### PR TITLE
New routing rule for brink/wpassets

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -356,6 +356,7 @@ _/braintree content ;
 _/bravi/archive content ;
 _/bravi/wp-assets content ;
 _/bridge content ;
+_/brink/wpassets content ;
 _/brownstone content ;
 _/brussels content ;
 _/bsl content ;


### PR DESCRIPTION
This is safe for production immediately (does not need to coordinate with other One Editorial work)