### PR TITLE
Remove RSS

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1730,7 +1730,6 @@ _/roybal content ;
 _/rpm/panos content ;
 _/rrtcout content ;
 _/rsg content ;
-_/rss content ;
 _/rvs content ;
 _/ryeany content ;
 _/saa content ;


### PR DESCRIPTION
more standard clean-up (not related to OneEd); retired pre-WP RSS directory/index page.