### PR TITLE
Update sites.map for non-WP directory-INC12701540

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1569,6 +1569,7 @@ _/ofa content ;
 _/offcampus content ;
 _/office365 content ;
 _/offices content ;
+_/ogc/wp-assets content ;
 _/oittest content ;
 _/old.law content ;
 _/om content ;


### PR DESCRIPTION
Route www.bu.edu/ogc/wp-assets/ for Telegraph Nelnet form files outside WP (INC12701540)