### PR TITLE
update docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 #FROM buist/websites-webrouter-base:2018.06.04
 #FROM buist/websites-webrouter-base:2018.06.07
 #FROM buist/websites-webrouter-base:2018.06.11
-FROM buist/websites-webrouter-base:2018.07.11
+FROM buist/websites-webrouter-base:2019.07.02
 
 # for now this is our split and everything below this is for a different location
 #


### PR DESCRIPTION
Updates the base docker image with a fix necessary for the One Editorial homepage edit/preview process.

Preview links for unpublished posts (without permalinks) go to the root site domain with just a query parameter like www.bu.edu/?page_id=1234&preview=true, so these need to be routed to WordPress.

The new docker base [contains this fix](https://github.com/bu-ist/webrouter-base/pull/1) which looks for query parameters on the root domain and routes them normally, instead of the custom home page location.