### PR TITLE
move state-authorization to WP

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1871,7 +1871,6 @@ _/sswphd content ;
 _/stamasfund content ;
 _/startup content ;
 _/state content ;
-_/state-authorization content ;
 _/stationery content ;
 _/stats content ;
 _/stay content ;


### PR DESCRIPTION
launch bu.edu/state-authorization as a WP site, so remove the 'content' listing in web routing