### PR TITLE
Non-WP www.bu.edu/family/wp-assets/ for INC12730474

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -874,6 +874,7 @@ _/fafc-files content ;
 _/fafc-temp content ;
 _/fafc/wp-assets content ;
 _/fames content ;
+_/family/wp-assets content ;
 _/familymed/distance content ;
 _/familymed/forms content ;
 _/familymed/meddebt content ;


### PR DESCRIPTION
Route /family/wp-assets around WordPress for directory with Telegraph Nelnet files and output for Application Fee Payment Form; Note: created directory on prod for new site in development on staging site...The Telegraph configuration file at https://www.bu.edu/family/wp-assets/telegraph/fee-config.xml includes a redirect directive for thank you page; currently using the staging URL for testing...but will needed to be updated after form testing and approval and before upcoming site launch, i.e. change <directive action="redirect" href="https://www-staging.bu.edu/family/our-programs/application-fee/thanks/" /> to <directive action="redirect" href="https://www.bu.edu/family/our-programs/application-fee/thanks/" />