### PR TITLE
wellbeing project take 2

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -49,7 +49,7 @@ _/sthfund https://trusted.bu.edu/s/1759/2-bu/giving/interior.aspx?sid=1759&gid=2
 _/victorycelebration http://www.bu.edu/campaign/campaign-victory-celebration/ ;
 _/victorytix https://www1.ticketmaster.com/celebration-of-bu/event/01005691E65EA340 ;
 _/wellbeingproject https://www.bu.edu/provost/wellbeingproject ;
-_/wellbeingproject/events https://www.bu.edu/provost/wellbeingproject/events ;
+_/wellbeingproject/events https://www.bu.edu/provost/wellbeingproject/wellbeing-project-events ;
 _/wheelockfamilytheatre https://trusted.bu.edu/s/1759/2-bu/giving/interior.aspx?sid=1759&gid=2&pgid=412&cid=1044&dids=436&appealcode=WEBAGC&bledit=1 ;
 
 # Other redirects


### PR DESCRIPTION
In order to add even more superfluous redundancy I'm changing the redirect target to /provost/wellbeingproject/wellbeing-project-events/ because, honestly, you JUST CAN'T GET ENOUGH WELLBEING, can ya?