### PR TITLE
 @lizmcguireBU Non-WP www.bu.edu/childrens-center/wp-assets/ for INC1…

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -559,6 +559,7 @@ _/chelmsford content ;
 _/childcognition content ;
 _/childhoodtrauma content ;
 _/childlabs content ;
+_/childrens-center/wp-assets content ;
 _/chinese content ;
 _/choosemet content ;
 _/ciap content ;


### PR DESCRIPTION
…2730474

Route /childrens-center/wp-assets around WordPress for directory with Telegraph Nelnet files and output for Application Fee Payment Form; Originally setup and tested as www-staging.bu.edu/family/ and prepped for www.bu.edu/family/ launch, but they changed from /family/ top-level URL to /childrens-center/, but did not inform me of change--so updating now, post launch; form is password protected, already activated output folder, will do final test, update, and then remove password.