### PR TITLE
add HRIS subdirectory as content

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1095,6 +1095,7 @@ _/hprp content ;
 _/hr/articulate content ;
 _/hr/documents content ;
 _/hr/flash content ;
+_/hr/hris content ;
 _/hr/wp-assets content ;
 _/hre content ;
 _/htbin.ph content ;


### PR DESCRIPTION
HR is putting non-WP content at bu.edu/hr/hris/ - adding HRIS to go to the content server