### PR TITLE
INC12799718 non-WP directory for web cam content

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1624,6 +1624,7 @@ _/perlstaff content ;
 _/personnel content ;
 _/phhprc content ;
 _/photo content ;
+_/photonics/av content ;
 _/phylogeny content ;
 _/phys-biophys content ;
 _/physics content ;


### PR DESCRIPTION
Update sites.map to create www.bu.edu/photonics/av/ directory that can be used for hosting web cam files outside WordPress (or additional non-WP AV file hosting); will suggest client uses www.bu.edu/photonics/av/web-cam/ subdirectory (or similar) for this  ticket to allow for future dept subdirectories that may have different user access/permissions.