### PR TITLE
Add a caching rule that can be used for /cdn/ site

### DIFF
--- a/landscape/prod/maps/cachecontrol.map
+++ b/landscape/prod/maps/cachecontrol.map
@@ -5,6 +5,8 @@
   legacy "no-cache, no-store" ;
   django "no-cache, no-store" ;
   content-nocache "no-cache, no-store" ;
+  content-cache "max-age=1800" ;
+
   # non-WordPress static content can not be
   # cached because Weblogin does not set the
   # no-cache header on protected content.

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -515,7 +515,7 @@ _/ccrd content ;
 _/cd content ;
 _/cdaly content ;
 _/cdc2007 content ;
-_/cdn content ;
+_/cdn content-cache ;
 _/ce content ;
 _/cedh content ;
 _/ceei content ;


### PR DESCRIPTION
Content served from the `content` backend must not be cached to the mechanism WebLogin uses. However, www.bu.edu/cdn doesn't use WebLogin, and contains content we'd want cached aggressively.

As a starting point, this PR adds a max-age=1800 caching rule for a `content-cache` configuration (using the same backend servers) and routes the `_/cdn/` site to that backend.

Besides the direct benefits of more caching, this solves a defect in IE11 where font files didn't render correctly, because IE11 requires a cache rule to exist for font files, because (probably) reasons.