### PR TITLE
Update for /summer-registration/wp-assets

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1916,6 +1916,7 @@ _/study content ;
 _/studyfinder content ;
 _/suemac content ;
 _/summer content ;
+_/summer-registration/wp-assets content ;
 _/summerfun content ;
 _/summerterm content ;
 _/supplier content ;


### PR DESCRIPTION
www.bu.edu/summer-registration/wp-assets contains the following Telegraph configuration files that need to be accessible outside of WordPress for testing and the launch of the summer and summer-registration sites. After this is complete I will update the form_location fields on the Telegraph forms to point to /summer-registration/wp-assets/telegraph/ so that this is a seamless update for users on staging (configs currently live on www.bu.edu/summer/wp-assets/telegraph/ and that entire site will be switching to WordPress shortly). After migration of staging to production, I will need to update the configuration files to use www.bu.edu instead of www-staging.bu.edu on redirect directives. 

•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-hs.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-hs-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-intl.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-intl-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-ssip.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_application_fee-ssip-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-hs-rise.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-hs-rise-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-hs.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-hs-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-intl.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-intl-test.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-ssip.xml 
•	http://www.bu.edu/summer-registration/wp-assets/telegraph/gf_tuition_deposit-ssip-test.xml