### PR TITLE
New routing for CeCredential application

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -142,6 +142,7 @@ _/law-pub        django ;
 # PHPBIN sites
 _/buniverse phpbin ;
 _/calendar phpbin-aws ;
+_/phpbin/cecredential phpbin-aws ;
 _/maps phpbin ;
 _/nisdev phpbin ;
 _/summer/courses-test phpbin ;


### PR DESCRIPTION
This puts our shiny new CeCredential application onto our shiny new AWS infrastructure. 

See Also: Shiny ; New