### PR TITLE
Redirect phpbin/coursedesc2 to phpbin/courses

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -56,6 +56,7 @@ _/medlib https://www.bumc.bu.edu/medlib/ ;
 _/nyc2020 https://www.bu.edu/alumni/leadership-celebration/ ;
 _/omba https://www.bu.edu/questrom/degree-programs/online-mba/ ;
 _/omba-admissions https://www.bu.edu/questrom/admissions/graduate-programs/online-mba/ ;
+_/phpbin/coursedesc2 https://www.bu.edu/phpbin/courses/update/ ;
 _/plr https://www.buplr.com/contact ;
 _/proudtobu https://www.bu.edu/alumni/news/proud-to-bu-podcast/ ;
 _/questrom-phd https://www.bu.edu/questrom/degree-programs/phd-program/ ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -144,6 +144,7 @@ _/law-pub        django ;
 _/buniverse phpbin ;
 _/calendar phpbin-aws ;
 _/phpbin/cecredential phpbin-aws ;
+_/phpbin/coursedesc2 redirect_asis ;
 _/maps phpbin ;
 _/nisdev phpbin ;
 _/summer/courses-test phpbin ;


### PR DESCRIPTION
The old coursedesc2 application is gone, and there's a new API in its place. We'll call this new thing `courses`.