### PR TITLE
Fix prior PR

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1006,7 +1006,6 @@ _/givetolaw content ;
 _/givetosph content ;
 _/givetowtbu content ;
 _/givingback content ;
-_/givingday content ;
 _/givingmatters content ;
 _/givingsocieties content ;
 _/givingtuesday content ;


### PR DESCRIPTION
Fixes a conflict in the prior PR, whereas "givingday" was defined as both content backend and redirect (content should have been removed in first PR)