### PR TITLE
HR form page emergency change

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -69,6 +69,7 @@ _/givingsocieties https://www.bu.edu/alumni/giving/who-gives/ ;
 _/goterriers https://trusted.bu.edu/s/1759/2-bu/giving/interior.aspx?sid=1759&gid=2&pgid=410&cid=1042&appealcode=WEBATH-PR ;
 _/headspace https://www.bu.edu/provost/wellbeingproject/wellbeing-project-resources/headspace/ ;
 _/hirequestrom https://www.bu.edu/questrom/careers/hire-questrom/ ;
+_/hr/covid-19-workplace-adjustment-request-form https://www.bu.edu/hr/covid-19-workplace-adjustment-request-form/ ;
 _/hubiejonesfund https://trusted.bu.edu/s/1759/2-bu/giving/interior.aspx?sid=1759&gid=2&pgid=464&cid=1122&dids=335&appealcode=WEBSSW ;
 _/hubiejonesrsvp https://bostonu.imodules.com/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=8634&content_id=10053 ;
 _/impact https://www.bu.edu/alumni/giving/impact ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -84,6 +84,7 @@ _/givingsocieties redirect_asis ;
 _/goterriers redirect_asis ;
 _/headspace redirect_asis ;
 _/hirequestrom redirect_asis ;
+_/hr/covid-19-workplace-adjustment-request-form redirect_asis ;
 _/hubiejonesfund redirect_asis ;
 _/hubiejonesrsvp redirect_asis ;
 _/impact redirect_asis ;


### PR DESCRIPTION
Thank you Ron, please go ahead.

TS

Tracy Schroeder | Vice President | she/her/hers
===================================
 
I attempted to use the Safe Redirect Manager (a WordPress plugin) to force https, but that failed to work. The page containing the form is served fine over https, but we do not have an easy way to force https, and it is a tangled problem that has proven challenging to prioritize with dwindling resources.
 
I can attempt an emergency change to the Amazon web routing to see if I can force https in that manner; essentially treating it as a marketing URL.
 
Ron