### PR TITLE
Update sites.map for INC12967544

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -979,6 +979,7 @@ _/feltensteinchallenge content ;
 _/festival content ;
 _/fetters content ;
 _/fhcmi content ;
+_/fhs/wp-assets content ;
 _/finaid wordpress ;
 _/finaid/fedfunds content ;
 _/finaid/pdfs content ;


### PR DESCRIPTION
This is a request for a Telegraph majordomo form on framinghamheartstudy.org; Ron advised that I could put the  /wp-assets/ static content directory at www.bu.edu/fhs/wp-assets/ and store the Telegraph configuration file, email template, and activated output directory there.