### PR TITLE
Update sites.map static bu.edu/law/course-planner

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1306,6 +1306,7 @@ _/latenightkitchen content ;
 _/laverdes content ;
 _/law.bkup content ;
 _/law/communications content ;
+_/law/course-planner content ;
 _/law/events content ;
 _/law/graphics content ;
 _/law/journals-archive content ;


### PR DESCRIPTION
Setting up directory for www.bu.edu/law/course-planner static site