### PR TITLE
MET events

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1496,7 +1496,6 @@ _/met/common content ;
 _/met/elive content ;
 _/met/email-campaign content ;
 _/met/event-calendar content ;
-_/met/events content ;
 _/met/forbes content ;
 _/met/grad11 content ;
 _/met/health-it content ;


### PR DESCRIPTION
Remove /met/events/ redirect since WP is now handling it