### PR TITLE
Update sites.map for wp-assets folder INC13071783

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1350,6 +1350,7 @@ _/openaccess redirect_asis ;
 _/opg redirect_asis ;
 _/orcid redirect_asis ;
 _/orientation2020/wp-assets content ;
+_/orientation2021/wp-assets content ;
 _/orl content ;
 _/orpm content ;
 _/ortho content ;


### PR DESCRIPTION
Add /wp-assets/ directory to be routed around WordPress for www.bu.edu/orientation2021 site. This is a new 2021 site created from clone of www.bu.edu/orientation2020 with annual updates for 2021 content updates and I need a directory for the Telegraph form files.