### PR TITLE
INC13083309 and INC13083274

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -123,6 +123,8 @@ _/phpbin/webdis phpbin-aws ;
 #
 #####################################################################
 
+_/1839gifts redirect_asis ; 
+_/1839society redirect_asis ;
 _/2020-year-in-review content ;
 _/28qatest content ;
 _/aaastudy redirect_asis ;


### PR DESCRIPTION
restore two missing directives:
_/1839gifts redirect_asis ; 
_/1839society redirect_asis ;
these had corresponding target URLs defined the in the redirects.map, but the directives here were missing. I believe these to be in the batch recently migrated from AFS redirects.