### PR TITLE
INC13103296

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -3,7 +3,6 @@
 #
 
 # StudentLink main menu
-_/applicantlink /link/bin/uiscgi_applicantlink.pl/uismpl ;
 _/employeelink /link/bin/uiscgi_employeelink.pl/uismpl ;
 _/geography/brdf http://www-modis.bu.edu/brdf ;
 _/studentlink /link/bin/uiscgi_studentlink.pl/uismpl/?ModuleName=menu.pl&NewMenu=Home ;


### PR DESCRIPTION
retiring /applicantlink redirect
INC12946498 explicitly asked us to remove the _/applicantlink entry from sites.map. There is no reason to have kept the entry in redirects.map past that point; it does nothing now, so removing it with this PR