### PR TITLE
Update sites.map for INC13151266

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1788,3 +1788,4 @@ _/youdo redirect_asis ;
 _/yourbusm redirect_asis ;
 _/yourgift redirect_asis ;
 _/yourimpact redirect_asis ;
+_/zerowasteplan redirect_asis ;


### PR DESCRIPTION
Redirect www.bu.edu/zerowasteplan to https://www.bu.edu/sustainability/what-were-doing/waste-reduction/zero-waste-plan/

Page is in draft status, but will be published shortly.