### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/test-nginx.yml
+++ b/.github/workflows/test-nginx.yml
@@ -1,0 +1,15 @@
+name: Check nginx config parsing
+
+on:
+  pull_request:
+    branches: [ prod ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the Docker image
+      run: docker build . --build-arg "landscape=prod" --tag webrouter:test
+    - name: Try parsing the configs
+      run: docker run -e "LANDSCAPE=prod" webrouter:test /usr/sbin/run-nginx.sh -t


### PR DESCRIPTION
Adds a GitHub action that builds the image with the 'prod' environment variable and runs the nginx test script.

It is setup to run on any PR into the `prod` branch, so the results will show directly in the context of the PR. This means reviewers can see the results of the tests before the review, instead of waiting until after it has been merged and sent to CodePipeline.

