### PR TITLE
Update to restore www.bu.edu/galacticring

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -653,6 +653,7 @@ _/fy102 redirect_asis ;
 _/fy103 redirect_asis ;
 _/fye redirect_asis ;
 _/fysopstyle redirect_asis ;
+_/galacticring content ;
 _/gastronomy redirect_asis ;
 _/gdp/china-debt-swap-climate-nature content ;
 _/gdp/chinas-overseas-development-finance content ;


### PR DESCRIPTION
INC13227624 came in because this site was miscategorized for archiving. Restoring the routing and will inform developer moving AFS static sites to new platform.