### PR TITLE
Update sites.map for bu.edu/strategicreport

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1304,7 +1304,7 @@ _/stay-test redirect_asis ;
 _/sthfund redirect_asis ;
 _/story static-public ;
 _/strategic-plan-taskforce redirect_asis ;
-_/strategicreport static-public ;
+_/strategicreport static-protected ;
 _/streambu redirect_asis ;
 _/student-health-services redirect_asis ;
 _/studentgiving redirect_asis ;


### PR DESCRIPTION
For INC13244308, missed this site in the last pull request--should be routed to static-protected