### PR TITLE
INC13363602

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -221,6 +221,7 @@ _/cwc http://www.bu.edu/shs/ ;
 _/danrather http://hgar-srv3.bu.edu/web/dan-rather/home/ ;
 _/dayofservice http://www.bu.edu/globaldaysofservice/ ;
 _/daysofservice http://www.bu.edu/globaldaysofservice/ ;
+_/dct https://www.bu.edu/ldt/ ;
 _/degreecomplete http://www.bu.edu/met/info-center/info-sessions-open-houses-webinars/adcp-info-session/ ;
 _/dentalassisting http://www.bu.edu/dental/ce/special-programs/dental-assisting-training-program1/ ;
 _/dentures http://www.bu.edu/dental/patients/dentures/ ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -568,6 +568,7 @@ _/data static-public ;
 _/data-sciences-center static-public ;
 _/dayofservice redirect_asis ;
 _/daysofservice redirect_asis ;
+_/dct redirect_asis ;
 _/dbin-cnsb-assets static-public ;
 _/dbin-cupidcubesat-data static-public ;
 _/dbin-dance static-public ;


### PR DESCRIPTION
Retiring www.bu.edu/dct/, and redirecting URL to new/updated site at www.bu.edu/ldt/.