### PR TITLE
Restore archived static site

### DIFF
--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -908,6 +908,7 @@ _/kpw/printsync redirect_asis ;
 _/kssf redirect_asis ;
 _/lab redirect_asis ;
 _/lacelebratesbu redirect_asis ;
+_/lamilpa static-public ;
 _/lamovie redirect_asis ;
 _/languagelearning redirect_asis ;
 _/languages redirect_asis ;


### PR DESCRIPTION
INC13416948 www.bu.edu/lamilpa/ - was bulk archived in 2021 (very old site) - they have asked for it back.