### PR TITLE
feature/people redirect

### DIFF
--- a/landscape/prod/maps/redirects.map
+++ b/landscape/prod/maps/redirects.map
@@ -1184,4 +1184,6 @@ www.todaysbaby.org https://sites.bu.edu/todaysbaby ;
 www.urbanarch.org https://sites.bu.edu/urbanarch ;
 www.wheelock.edu https://www.bu.edu/wheelock/ ;
 
+
+people.bu.edu/_domains/people.bu.edu https://people.bu.edu/ ;
 people.bu.edu/jnoor https://sites.bu.edu/jnoor/ ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1429,7 +1429,6 @@ _/wcrew redirect_asis ;
 _/webcentral/common static-public ;
 _/weblogin static-protected ;
 _/webteam/hiring static-public-nocache ;
-_/webteam/presentations static-protected ;
 _/webteam/projects static-public-nocache ;
 _/wellbeingproject redirect_asis ;
 _/wellbeingproject/events redirect_asis ;

--- a/landscape/prod/maps/sites.map
+++ b/landscape/prod/maps/sites.map
@@ -1776,6 +1776,7 @@ _/gms/review_form static-public ;
 
 # people.bu.edu
 people.bu.edu people-public ;
+people.bu.edu/_domains/people.bu.edu redirect-asis ;
 
 # Sites with .shtml files:
 people.bu.edu/alyasoff people-protected ;


### PR DESCRIPTION
- Remove /webteam/presentations/
- Account for trailing slash redirects coming from S3.
