### PR TITLE
feature/people no cache

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1843,4 +1843,4 @@ people.bu.edu/somers people-protected ;
 people.bu.edu/temkin people-protected ;
 people.bu.edu/tgoss redirect_asis ;
 people.bu.edu/wonglab people-protected ;
-people.bu.edu/xinz people-nocache ;
+people.bu.edu/xinz people-public-nocache ;


### PR DESCRIPTION
- Introduce a people-nocache configuration to disable caching on one specific site.
- Remap people.bu.edu/xinz to people-public-nocache
