### PR TITLE
Revert "Move people.bu.edu/rcarney to public sites (.htaccess was just for a redirect)"

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1862,6 +1862,7 @@ people.bu.edu/ottest people-protected ;
 people.bu.edu/peverett people-protected ;
 people.bu.edu/pierson redirect_asis ;
 people.bu.edu/rbs people-protected ;
+people.bu.edu/rcarney people-protected ;
 people.bu.edu/rudi people-protected ;
 people.bu.edu/salge people-protected ;
 people.bu.edu/scottm people-protected ;


### PR DESCRIPTION
This reverts commit b0037a2fb998973c3e36a1b517033c203145f863.

Turns out there are also .shtml files in here.
