### PR TITLE
INC13610987

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -1234,6 +1234,7 @@ bumc.bu.edu/publicsafety https://www.bu.edu/police/contact/contact-bumc-public-s
 
 sites.bu.edu/akwok https://sites.bu.edu/slhs-recruiting/ ;
 
+people.bu.edu/cjmartin https://blogs.bu.edu/cjmartin/ ;
 people.bu.edu/cstepp https://sites.bu.edu/stepplab/ ;
 people.bu.edu/ecohn https://www.bu.edu/sargent/profile/ellen-cohn/ ;
 people.bu.edu/gvoysey http://gvoysey.github.io/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1840,6 +1840,7 @@ people.bu.edu/arn people-protected ;
 people.bu.edu/azs people-protected ;
 people.bu.edu/cball people-protected ;
 people.bu.edu/celenza people-protected ;
+people.bu.edu/cjmartin redirect_asis ;
 people.bu.edu/cstepp redirect_asis ;
 people.bu.edu/dako people-protected ;
 people.bu.edu/dsmk people-protected ;


### PR DESCRIPTION
Add redirect for old people.bu.edu to replace sites.bu.edu URL