### PR TITLE
mURL for webticket

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -870,6 +870,7 @@ _/washingtoncelebratesbu http://bostonu.imodules.com/s/1759/2-bu/2col.aspx?sid=1
 _/washintern http://www.bu.edu/abroad/programs/washington-dc-internship-program/ ;
 _/wcrew https://sparksconsult.com/sports/rowing/sparks-camps/summer-rowing-camps/bu-rowing-camp ;
 _/webcentral https://www.bu.edu/webteam/ ;
+_/webticket https://bu.service-now.com/sp?id=sc_category&sys_id=9498a5951b226490b068ed70604bcb64&catalog_id=-1&spa=1 ;
 _/wellbeingproject https://www.bu.edu/provost/wellbeingproject ;
 _/wellbeingproject/events https://www.bu.edu/provost/wellbeingproject/wellbeing-project-events ;
 _/whatsnew https://www.bu.edu/today/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1450,6 +1450,7 @@ _/webcentral/common static-public ;
 _/weblogin static-protected ;
 _/webteam/hiring static-public-nocache ;
 _/webteam/projects static-public-nocache ;
+_/webticket redirect_asis ;
 _/wellbeingproject redirect_asis ;
 _/wellbeingproject/events redirect_asis ;
 _/wgrimes static-public ;


### PR DESCRIPTION
Creates bu.edu/webticket/ as a marketing URL to the web sites service portal page in Service Now.