### PR TITLE
Retire and redirect old site

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -136,6 +136,7 @@ _/bunano http://www.bu.edu/bu-nano/ ;
 _/bunextchicago https://bostonu.imodules.com/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=8188&content_id=9410 ;
 _/bunextla https://bostonu.imodules.com/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=8185&content_id=9408 ;
 _/bunextsf https://bostonu.imodules.com/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=8182&content_id=9406 ;
+_/bunow https://www.bu.edu/today/ ;
 _/burc http://www.bu.edu/urlc/ ;
 _/burppe http://www.bu.edu/sph/ ;
 _/burst https://www.facebook.com/BurstBU/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -387,6 +387,7 @@ _/bunano redirect_asis ;
 _/bunextchicago redirect_asis ;
 _/bunextla redirect_asis ;
 _/bunextsf redirect_asis ;
+_/bunow redirect_asis ;
 _/burc redirect_asis ;
 _/burppe redirect_asis ;
 _/burst redirect_asis ;


### PR DESCRIPTION
BU Now was ancient and still live using an old Flexi theme and had content no more recent than 2014. Archiving site per Jon Brousseau