### PR TITLE
retire & redirect academic-integrity

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -13,6 +13,7 @@ _/1839society https://www.bu.edu/alumni/giving/who-gives/1839-society/ ;
 _/aaastudy http://www.bu.edu/autismconnections ;
 _/aboutcgs http://www.bu.edu/cgs/about/prospective-students/ ;
 _/abroadatbu http://www.bu.edu/metinternational ;
+_/academic-integrity https://www.bu.edu/provost/students/undergraduate/academic-integrity/ ;
 _/academy http://www.buacademy.org/ ;
 _/acs http://www.bu.edu/computing/accounts/acs ;
 _/activecontrol https://psa.buw.bu.edu/activecontrol ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -160,6 +160,7 @@ _/aboutcgs redirect_asis ;
 _/abroad/av static-protected ;
 _/abroad/wp-assets static-public ;
 _/abroadatbu redirect_asis ;
+_/academic-integrity redirect_asis ;
 _/academics/archive static-public ;
 _/academy redirect_asis ;
 _/acs redirect_asis ;


### PR DESCRIPTION
INC13695613 - retire standalone site and redirect the URL to internal section within Provost's website