### PR TITLE
Lizmcguire bu patch 1

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -1250,6 +1250,7 @@ bumc.bu.edu/publicsafety https://www.bu.edu/police/contact/contact-bumc-public-s
 sites.bu.edu/agingny https://thenetwork.bu.edu/nysofa-training-academy/ ;
 sites.bu.edu/akwok https://sites.bu.edu/slhs-recruiting/ ;
 sites.bu.edu/geddesgrants https://www.bu.edu/geddes/resources/faculty-mini-grants/ ;
+sites.bu.edu/hothouse https://sites.bu.edu/real-world-productions/ ;
 sites.bu.edu/musicbridge https://www.bu.edu/cfa/students/music/ ;
 sites.bu.edu/reinhartlab https://reinhartlab.org/ ;
 

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1835,6 +1835,7 @@ blogs.bu.edu/vschmidt redirect_asis ;
 sites.bu.edu/agingny redirect_asis ;
 sites.bu.edu/akwok redirect ;
 sites.bu.edu/geddesgrants redirect_asis ;
+sites.bu.edu/hothouse redirect_asis ;
 sites.bu.edu/maasap/lgbt-aging-project static-custom-domain-sitesbuedu-nocache ;
 sites.bu.edu/musicbridge redirect_asis ;
 sites.bu.edu/reinhartlab redirect_asis ;


### PR DESCRIPTION
https://sites.bu.edu/real-world-productions/ was launched from staging and replaces previous site, https://sites.bu.edu/hothouse/; Jonathan S from Comms requested that current https//sites.bu.edu/hothouse/ be archived and redirected to https://sites.bu.edu/real-world-productions/. I have already archived the live sites.bu.edu/hothouse; this pull request is for the redirect. 

(I renamed the previous archive to https://cms-attic.bu.edu/hothouse-2016 used the clone function to archive live site to https://cms-attic.bu.edu/hothouse/. Because the new version has a different URL and this site is already archived, after this redirect is in place, I will delete sites.bu.edu/hothouse. 