### PR TITLE
feature/phpbin security

### DIFF
--- a/maps/cachecontrol.map
+++ b/maps/cachecontrol.map
@@ -1,5 +1,5 @@
   uiscgi_app "no-cache, no-store" ;
-  phpbin "no-cache, no-store" ;
+  phpbin-legacy "no-cache, no-store" ;
   dbin "no-cache, no-store" ;
   legacy "no-cache, no-store" ;
   django "no-cache, no-store" ;

--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -52,7 +52,7 @@ wordpress <%= ENV['BACKEND_WP_APP'] || "ist-wp-app-#{ENV['LANDSCAPE']}.bu.edu" %
 
 dbin <%= ENV['BACKEND_DBIN'] || "ist-web-dbin-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
-phpbin <%= ENV['BACKEND_PHPBIN'] || "ist-web-phpbin-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+phpbin-legacy <%= ENV['BACKEND_PHPBIN'] || "ist-web-phpbin-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 phpbin-aws ist-web-phpbin-aws-prod.bu.edu ;
 
 # Custom Domain for wiki.bu.edu:

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -86,7 +86,6 @@ _/courseware-manager     django ;
 
 _/buniverse phpbin-aws ;
 _/calendar phpbin-aws ;
-_/nisdev phpbin ;
 
 # dbin:
 
@@ -110,9 +109,6 @@ _/dbin/stemcells redirect_asis ;
 
 
 # phpbin:
-
-_/phpbin phpbin ;
-_/wiki phpbin ;
 
 _/phpbin/calendar phpbin-aws ;
 _/phpbin/cashier-admin redirect_asis ;
@@ -142,6 +138,7 @@ _/phpbin/signup phpbin-aws ;
 _/phpbin/sleep phpbin-aws ;
 _/phpbin/ssw-network phpbin-aws ;
 _/phpbin/static-sites phpbin-aws ;
+_/phpbin/telegraph phpbin-legacy ;
 _/phpbin/training phpbin-aws ;
 _/phpbin/webdis phpbin-aws ;
 _/phpbin/wiki phpbin-aws ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -137,6 +137,7 @@ _/phpbin/medlib phpbin-aws ;
 _/phpbin/organ-library phpbin-aws ;
 _/phpbin/parking phpbin-aws ;
 _/phpbin/proxy-groups phpbin-aws ;
+_/phpbin/security phpbin-aws ;
 _/phpbin/signup phpbin-aws ;
 _/phpbin/sleep phpbin-aws ;
 _/phpbin/ssw-network phpbin-aws ;


### PR DESCRIPTION
- Route phpbin/security to AWS
- Identify phpbin/telegraph as 'phpbin-legacy' and eliminate all other routing to legacy servers
