### PR TITLE
Revert all /help/ changes today

### DIFF
--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -57,7 +57,7 @@ phpbin-aws ist-web-phpbin-aws-prod.bu.edu ;
 www-rewrite-wiki ist-web-phpbin-aws-prod.bu.edu/phpbin/wiki ;
 
 # Custom for /help/ URLs:
-www-rewrite-tech-help-forms ist-web-phpbin-aws-prod.bu.edu/phpbin/marconi/tech-help-forms ;
+www-rewrite-tech-help-forms ist-web-phpbin-prod.bu.edu/phpbin/marconi/tech-help-forms ;
 
 
 # # # # # # # # # # # # # # # # # # # #

--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -59,7 +59,7 @@ phpbin-aws ist-web-phpbin-aws-prod.bu.edu ;
 www-rewrite-wiki ist-web-phpbin-aws-prod.bu.edu/phpbin/wiki ;
 
 # Custom for /help/ URLs:
-www-rewrite-tech-help-forms ist-web-phpbin-prod.bu.edu/phpbin/marconi/tech-help-forms ;
+www-rewrite-tech-help ist-web-phpbin-prod.bu.edu/phpbin/marconi/tech-help-forms ;
 
 
 # # # # # # # # # # # # # # # # # # # #

--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -58,8 +58,6 @@ phpbin-aws ist-web-phpbin-aws-prod.bu.edu ;
 # Custom Domain for wiki.bu.edu:
 www-rewrite-wiki ist-web-phpbin-aws-prod.bu.edu/phpbin/wiki ;
 
-# Custom for /help/ URLs:
-www-rewrite-tech-help ist-web-phpbin-prod.bu.edu/phpbin/marconi/tech-help-forms ;
 
 
 # # # # # # # # # # # # # # # # # # # #

--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -46,11 +46,13 @@ people-protected ist-web-static-sites-prod.bu.edu/_domains/people.bu.edu ;
 wpassets <%= ENV['BACKEND_WP_CONTENT'] || "ist-wp-app-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 wordpress <%= ENV['BACKEND_WP_APP'] || "ist-wp-app-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 
-
 # # # # # # # # # # # # # # # # # # # #
 #  PHP
 # # # # # # # # # # # # # # # # # # # #
 
+dbin <%= ENV['BACKEND_DBIN'] || "ist-web-dbin-#{ENV['LANDSCAPE']}.bu.edu" %> ;
+
+phpbin-legacy <%= ENV['BACKEND_PHPBIN'] || "ist-web-phpbin-#{ENV['LANDSCAPE']}.bu.edu" %> ;
 phpbin-aws ist-web-phpbin-aws-prod.bu.edu ;
 
 # Custom Domain for wiki.bu.edu:

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -89,6 +89,7 @@ _/calendar phpbin-aws ;
 
 # dbin:
 
+_/dbin dbin ;
 _/dbin/agni phpbin-aws ;
 _/dbin/archives static-public ;
 _/dbin/bands phpbin-aws ;
@@ -137,6 +138,7 @@ _/phpbin/signup phpbin-aws ;
 _/phpbin/sleep phpbin-aws ;
 _/phpbin/ssw-network phpbin-aws ;
 _/phpbin/static-sites phpbin-aws ;
+_/phpbin/telegraph phpbin-legacy ;
 _/phpbin/training phpbin-aws ;
 _/phpbin/webdis phpbin-aws ;
 _/phpbin/wiki phpbin-aws ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -815,7 +815,7 @@ _/healthmatters redirect_asis ;
 _/healthmba redirect_asis ;
 _/healthway redirect_asis ;
 _/hello-restricted static-protected ;
-_/help www-rewrite-tech-help-forms ;
+_/help phpbin-legacy ;
 _/help/tech-status static-protected ;
 _/help/wordpress redirect_asis ;
 _/helpinfo redirect_asis ;


### PR DESCRIPTION
- Revert "Correct hostname for www-rewrite-tech-help-forms"
- Revert "Remove legacy PHP servers"
- Revert "Fix hostname for /help/tech/ forms"
- Revert "Route /help/ to /phpbin/marconi/ endpoint"
