### PR TITLE
feature/sites autismsa training

### DIFF
--- a/maps/backend_hostheader.map
+++ b/maps/backend_hostheader.map
@@ -28,10 +28,7 @@ static-public static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
 static-public-nocache static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
 
 static-custom-domain-madlab static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
-
-static-custom-domain-sitesbuedu static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
 static-custom-domain-sitesbuedu-nocache static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
-
 static-custom-domain-framinghamheartstudy-nocache static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;
 
 people-public static-sites-prod-public.s3-website-us-east-1.amazonaws.com ;

--- a/maps/backend_scheme.map
+++ b/maps/backend_scheme.map
@@ -22,10 +22,7 @@ static-public http ;
 static-public-nocache http ;
 
 static-custom-domain-madlab http ;
-
-static-custom-domain-sitesbuedu http ;
 static-custom-domain-sitesbuedu-nocache http ;
-
 static-custom-domain-framinghamheartstudy-nocache http ;
 
 people-public http ;

--- a/maps/hosts.map.erb
+++ b/maps/hosts.map.erb
@@ -23,7 +23,6 @@ static-protected ist-web-static-sites-prod.bu.edu ;
 
 static-custom-domain-madlab static-sites-prod-public.s3-website-us-east-1.amazonaws.com/_domains/www.madlab.bu.edu ;
 
-static-custom-domain-sitesbuedu static-sites-prod-public.s3-website-us-east-1.amazonaws.com/_domains/sites.bu.edu ;
 static-custom-domain-sitesbuedu-nocache static-sites-prod-public.s3-website-us-east-1.amazonaws.com/_domains/sites.bu.edu ;
 
 static-custom-domain-framinghamheartstudy-nocache static-sites-prod-public.s3-website-us-east-1.amazonaws.com/_domains/www.framinghamheartstudy.org ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1863,7 +1863,7 @@ blogs.bu.edu/vschmidt redirect_asis ;
 # sites.bu.edu
 sites.bu.edu/agingny redirect_asis ;
 sites.bu.edu/akwok redirect ;
-sites.bu.edu/autismsa/training static-public ;
+sites.bu.edu/autismsa/training static-custom-domain-sitesbuedu-nocache ;
 sites.bu.edu/geddesgrants redirect_asis ;
 sites.bu.edu/hothouse redirect_asis ;
 sites.bu.edu/maasap redirect_asis ;


### PR DESCRIPTION
- Remove static-custom-domain-sitesbuedu (nocache is now the only option):
- Switch sites.bu.edu/autismsa/training to custom domain config
