### PR TITLE
Redirects for retired pages on sites.bu.edu

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -1318,8 +1318,10 @@ sites.bu.edu/hothouse https://sites.bu.edu/real-world-productions/ ;
 sites.bu.edu/maasap https://thenetwork.bu.edu/massachusetts-training-portal/ ;
 sites.bu.edu/musicbridge https://www.bu.edu/cfa/students/music/ ;
 sites.bu.edu/reinhartlab https://reinhartlab.org/ ;
+sites.bu.edu/techlaw https://www.bu.edu/law/experiential-learning/clinics/bu-mit-student-innovations-law-clinic/ ;
 sites.bu.edu/shield-drive https://shielddrivecenter.com ;
 sites.bu.edu/signlab https://sites.bu.edu/slde/ ;
+sites.bu.edu/startuplaw https://www.bu.edu/law/experiential-learning/clinics/bu-mit-student-innovations-law-clinic/ ;
 sites.bu.edu/southcampus https://www.bu.edu/reslife/ ;
 sites.bu.edu/vschmidt https://www.vivienaschmidt.com ;
 

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1898,9 +1898,11 @@ sites.bu.edu/hothouse redirect_asis ;
 sites.bu.edu/maasap redirect_asis ;
 sites.bu.edu/musicbridge redirect_asis ;
 sites.bu.edu/reinhartlab redirect_asis ;
+sites.bu.edu/techlaw redirect_asis ;
 sites.bu.edu/shield-drive redirect_asis ;
 sites.bu.edu/signlab redirect_asis ;
 sites.bu.edu/southcampus redirect_asis ;
+sites.bu.edu/startuplaw redirect_asis ;
 sites.bu.edu/vschmidt redirect_asis ;
 
 # people.bu.edu


### PR DESCRIPTION
sites.bu.edu/techlaw
sites.bu.edu/startuplaw