### PR TITLE
Redirect from bu.edu/inauguration to bu.edu/inauguration-2024 - RITM2026096

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -427,6 +427,7 @@ _/id https://www.bu.edu/marcom/ ;
 _/ihs https://www.bu.edu/european/ ;
 _/ihsip https://www.bu.edu/research/ ;
 _/impact https://www.bu.edu/alumni/giving/impact/ ;
+_/inauguration https://www.bu.edu/inauguration-2024 ;
 _/infancp https://www.bu.edu/infantcp/ ;
 _/infocenter https://www.bu.edu/about/ ;
 _/infosec https://www.bu.edu/tech/support/information-security/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -827,6 +827,7 @@ _/igsw static-public ;
 _/ihs redirect_asis ;
 _/ihsip redirect_asis ;
 _/impact redirect_asis ;
+_/inauguration redirect_asis ;
 _/index.html aws_home ;
 _/indigobirds static-public ;
 _/infancp redirect_asis ;


### PR DESCRIPTION
RITM2026096 includes a request to setup redirect from bu.edu/inauguration to bu.edu/inauguration-2024. 