### PR TITLE
Update redirects.map - INC20424806

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -202,7 +202,7 @@ _/childcognition https://www.bu.edu/cdl/ccl/ ;
 _/cho https://www.bu.edu/chiefhealthoffice/ ;
 _/cilse https://www.bu.edu/kilachandcenter/ ;
 _/cip https://www.bu.edu/consumer/ ;
-_/claflinsociety https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=15123&content_id=16989 ;
+_/claflinsociety https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=16134&content_id=17946 ;
 _/classroom https://www.bu.edu/classrooms/ ;
 _/climate https://www.bu.edu/earth/ ;
 _/climateactionplan https://www.bu.edu/sustainability/vision-progress/climate-action-plan-2/ ;


### PR DESCRIPTION
URL: `bu.edu/claflinsociety`

Current redirect: Boston University Alumni - Annual Claflin Society Spring Luncheon (bu.edu)
`https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=15123&content_id=16989`

New redirect: Boston University Alumni - Annual Claflin Society Fall Reception (bu.edu)
`https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=16134&content_id=17946`