### PR TITLE
Lizmcguire bu patch 2

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -561,6 +561,7 @@ _/mbanext https://www.bu.edu/mbainfo/?utm_source=mbta&utm_medium=station%20poste
 _/mbanorth https://www.bu.edu/questrom/pemba/?utm_source=LRTA&utm_medium=Bus%20Posters&utm_content=MBAnorth&utm_campaign=PEMBA%20Because ;
 _/mbapathway https://www.bu.edu/mbainfo/attend-an-info-session/?utm_source=q1%20media&utm_medium=podcast%20audio&utm_campaign=mba&utm_content=fall%20events&tfa_4=q1%20media&tfa_3=podcast%20audio&tfa_1=mba&tfa_2=fall%20events ;
 _/mbasession https://www.bu.edu/mbainfo/?utm_source=spotify&utm_medium=30%20second%20spot&utm_content=mba%20session&utm_campaign=pemba ;
+_/mbs https://sites.bu.edu/mbs/ ;
 _/mbta https://www.bu.edu/questrom/pemba/?utm_source=mbta&utm_medium=MBTAads&utm_campaign=BackBayAug2012 ;
 _/mdparents https://www.bumc.bu.edu/busm/parents/ ;
 _/medalum https://www.bu.edu/medalumni/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -994,6 +994,7 @@ _/mbanext redirect_asis ;
 _/mbanorth redirect_asis ;
 _/mbapathway redirect_asis ;
 _/mbasession redirect_asis ;
+_/mbs redirect_asis ;
 _/mbta redirect_asis ;
 _/mch redirect_asis ;
 _/mdparents redirect_asis ;


### PR DESCRIPTION
INC20430561 update student group site that was created on the wrong network (www.bu.edu is reserved for BU Schools/Collleges, departments, major university initiatives. Student group sites registered with SAO are eligible for sites.bu.edu so updating this URL and creating redirect so that it's in the correct network at https://sites.bu.edu/mbs/ (we will redirect traffic that comes to www.bu.edu/mbs/ to https://sites.bu.edu/mbs/)