### PR TITLE
Update sites.map

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -913,7 +913,6 @@ _/lifebook redirect_asis ;
 _/lifelong redirect_asis ;
 _/lifelonglearning redirect_asis ;
 _/lifesciences redirect_asis ;
-_/linguistics static-protected ;
 _/links redirect_asis ;
 _/links2 redirect_asis ;
 _/lite static-public ;


### PR DESCRIPTION
RITM2040056 - remove entry for linguistics pointing to static-protected because they are launching a WP site.