### PR TITLE
Disable /htbin as last real activity was removed by INC20372376

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -59,7 +59,9 @@ _/uiszl_j2ee legacy ;
 _/uiszl_pdf legacy ;
 
 # old CGI script locations (right now we send those to the existing Solaris backend)
-_/htbin legacy ;
+
+# The following path is no longer necessary and I scanned logs to confirm that recent actvity was only 404s -dsmk 11/26/2024
+#_/htbin legacy ;
 _/testing legacy ;
 
 


### PR DESCRIPTION
/htbin legacy content mapping no longer needed as last legitimate use case was retired in INC20372376.  This pull request removes access but we won't shut down the backend until all other legacy backend use cases have been replaced - this means that it can easily be restored by uncommenting the /htbin entry.