### PR TITLE
Update redirects.map

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -202,7 +202,7 @@ _/childcognition https://www.bu.edu/cdl/ccl/ ;
 _/cho https://www.bu.edu/chiefhealthoffice/ ;
 _/cilse https://www.bu.edu/kilachandcenter/ ;
 _/cip https://www.bu.edu/consumer/ ;
-_/claflinsociety https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=17637&content_id=19125 ;
+_/claflinsociety https://bulegacy.org/?pageID=1003 ;
 _/classroom https://www.bu.edu/classrooms/ ;
 _/climate https://www.bu.edu/earth/ ;
 _/climateactionplan https://www.bu.edu/sustainability/vision-progress/climate-action-plan-2/ ;


### PR DESCRIPTION
INC20612735 - Redirect Destination update: 
- URL: bu.edu/claflinsociety

Current redirect URL: https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=17637&content_id=19125

New redirect URL: https://bulegacy.org/?pageID=1003