### PR TITLE
Lizmcguire bu patch 1

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -98,7 +98,6 @@ _/backtoschool https://www.bu.edu/alumni/ ;
 _/bashoexpress https://www.bu.edu/dining/location/basho-express/ ;
 _/bcdsp https://bcdsp.org/ ;
 _/bcrhhr https://www.bcrhhr.com/ ;
-_/bdc https://bdc.bu.edu ;
 _/bedac https://www.bu.edu/sph/research/centers-and-groups/biostatistics-and-epidemiology-data-analytics-center-bedac/ ;
 _/behavneuro https://www.bu.edu/psych/profile/kathleen-kantak-phd/ ;
 _/beijing2014 https://www.bu.edu/alumni/ ;

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -264,7 +264,6 @@ _/barc static-public ;
 _/bashoexpress redirect_asis ;
 _/bcdsp redirect_asis ;
 _/bcrhhr redirect_asis ;
-_/bdc redirect_asis ;
 _/bedac redirect_asis ;
 _/behavneuro redirect_asis ;
 _/beijing2014 redirect_asis ;


### PR DESCRIPTION
Launched new BU WordPress site at www.bu.edu/bdc/ which will be replacing the non-BU WP site at custom domain bdc.bu.edu which the client is archiving and redirecting to www.bu.edu/bdc/ after this site launches. This pull request is to remove the existing redirect that points to the custom domain non-BU WP site. 