### PR TITLE
Fix redirect for genchem.bu.edu to prevent double-slash 

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -1019,7 +1019,7 @@ engineering.bu.edu https://www.bu.edu/eng/admissions/graduate/ ;
 fitrec.bu.edu https://www.bu.edu/fitrec/ ;
 forms.wheelock.edu https://www.bu.edu/wheelock/ ;
 fraunhofer.bu.edu https://www.bu.edu/fhcmi/ ;
-genchem.bu.edu https://www.bu.edu/genchem/ ;
+genchem.bu.edu https://www.bu.edu/genchem ;
 geography.bu.edu https://www.bu.edu/earth/ ;
 givingday.bu.edu https://give.bu.edu/giving-day/ ;
 givingday.bu.edu/campaigns/frederick-s-pardee-school-of-global-studies-fund https://give.bu.edu/schools/BostonUniversity/giving-day/pages/pardee-school-of-global-studies ;
@@ -1271,4 +1271,5 @@ people.bu.edu/sidr https://sites.bu.edu/ramachandranlab/ ;
 people.bu.edu/tgoss https://theodoragoss.com/ ;
 
 people.bu.edu/theochem https://sites.bu.edu/theochem/ ;
+
 


### PR DESCRIPTION
Webrouter’s redirect engine automatically normalizes directory targets by appending a trailing slash...but in this case, it was causing a double slash.