### PR TITLE
INC20805644 - Marketing URL

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -819,6 +819,7 @@ _/ssw24 https://give.bu.edu/campaigns/56402/donations/new ;
 _/ssw25 https://give.bu.edu/campaigns/56402/donations/new ;
 _/ssw26 https://give.bu.edu/campaigns/56402/donations/new?a=11210093 ;
 _/sswemergencyfund https://give.bu.edu/campaigns/56402/donations/new?designation_id=9300011728 ;
+_/sswfacultyreview https://wwwapp.bumc.bu.edu/FacultyDevelopment/ ;
 _/stay http://stay.bu.edu ;
 _/stay-test http://stay-test.bu.edu ;
 _/sth24 https://give.bu.edu/campaigns/56408/donations/new ;
@@ -1275,5 +1276,6 @@ people.bu.edu/sidr https://sites.bu.edu/ramachandranlab/ ;
 people.bu.edu/tgoss https://theodoragoss.com/ ;
 people.bu.edu/theochem https://sites.bu.edu/theochem/ ;
 people.bu.edu/xinz https://sites.bu.edu/xinzhang-lab/;
+
 
 

--- a/maps/sites.map
+++ b/maps/sites.map
@@ -1327,6 +1327,7 @@ _/ssw24 redirect_asis ;
 _/ssw25 redirect_asis ;
 _/ssw26 redirect_asis ;
 _/sswemergencyfund redirect_asis ;
+_/sswfacultyreview redirect_asis ;
 _/stay redirect_asis ;
 _/stay-test redirect_asis ;
 _/sth24 redirect_asis ;
@@ -1890,3 +1891,4 @@ people.bu.edu/tgoss redirect_asis ;
 people.bu.edu/theochem redirect_asis ;
 people.bu.edu/wonglab people-protected ;
 people.bu.edu/xinz redirect_asis ;
+


### PR DESCRIPTION
Request to have the URL https://www.bu.edu/SSWFacultyReview redirect to https://wwwapp.bumc.bu.edu/FacultyDevelopment/? They are expanding the system beyond just the Medical Campus, so we want to be able to share a link that is not Medical Campus specific.