### PR TITLE
Update COI redirect

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -233,7 +233,7 @@ _/cme https://www.bumc.bu.edu/cme/ ;
 _/cnr25 https://give.bu.edu/campaigns/54534/donations/new?designation=centerforneurorehabilitationfund&a=8945802 ;
 _/cod https://www.bu.edu/provost/about/committees/council-of-deans/ ;
 _/cohenchallenge https://www.bu.edu/alumni/giving/ ;
-_/coi http://isps.bu.edu/applications/coi/ ;
+_/coi https://appnet.bu.edu/cozclientvue/ ;
 _/com/narrative https://combeyond.bu.edu/offering/the-power-of-narrative-conference/ ;
 _/com-csc https://www.bu.edu/com/for-current-students/career-services/ ;
 _/com24 https://give.bu.edu/campaigns/56400/donations/new ;


### PR DESCRIPTION
via email from Chris:
Hi Ron, is it pretty quick to change a marketing URL redirect? You can see my thread below – looks like there is a redirect on bu.edu/coi to go to an old link for this app that is no longer used and just spins. I can tell it was the old COI app given the email I found in 2006 (screenshot below). Ideally anything www.bu.edu/coi (http or https, whatever) would go to the correct COI app - https://appnet.bu.edu/cozclientvue...
 
-C