### PR TITLE
Update redirects.map for INC20864801

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -219,7 +219,7 @@ _/chips https://www.bu.edu/eng/research-impact/chips/ ;
 _/cho https://www.bu.edu/chiefhealthoffice/ ;
 _/cilse https://www.bu.edu/kilachandcenter/ ;
 _/cip https://www.bu.edu/consumer/ ;
-_/claflinsociety https://bulegacy.org/?pageID=1003 ;
+_/claflinsociety https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=19473&content_id=20639 ;
 _/classroom https://www.bu.edu/classrooms/ ;
 _/climate https://www.bu.edu/earth/ ;
 _/climateactionplan https://www.bu.edu/sustainability/vision-progress/climate-action-plan-2/ ;


### PR DESCRIPTION
new redirect for Planned Giving marketing URL:
URL: bu.edu/claflinsociety
Previous redirect: https://bulegacy.org/?pageID=1003 New redirect: https://trusted.bu.edu/s/1759/2-bu/19/1col.aspx?sid=1759&gid=2&pgid=19473&content_id=20639