### PR TITLE
Update redirects.map - INC20892085

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -25,7 +25,7 @@ _/abroadatbu https://www.bu.edu/metinternational/ ;
 _/academic-integrity https://www.bu.edu/provost/students/undergraduate/academic-integrity/ ;
 _/academy https://www.buacademy.org/ ;
 _/acs https://www.bu.edu/tech/services/security/iam/buid/overview-of-account-types/ ;
-_/activecontrol https://psa.buw.bu.edu/activecontrol ;
+_/activecontrol https://pbt.buw.bu.edu/activecontrol ;
 _/activistlab https://www.bu.edu/sph/practice/activist-lab/ ;
 _/actuary https://www.bu.edu/met/programs/actuarial-science/?utm_campaign=Actuarial-Programs&utm_medium=&utm_source=Actuarial-Programs-Page/ ;
 _/adapt https://adapt.bumc.bu.edu/ ;


### PR DESCRIPTION
Setting up for INC20892085: bu.edu/activecontrol currently points to https://psa.buw.bu.edu/activecontrol. As part of CHG2012101, we need to update the redirect to point to https://pbt.buw.bu.edu/activecontrol at noon on 5/17.