### PR TITLE
Update redirects.map

### DIFF
--- a/maps/redirects.map
+++ b/maps/redirects.map
@@ -635,7 +635,7 @@ _/navyrotc https://www.bu.edu/rotc/navy/ ;
 _/need26 https://give.bu.edu/campaigns/50118/donations/new?a=13107501&designation=busareaofgreatestneed ;
 _/neurophotonics-nrt https://www.bu.edu/neurophotonics/training/ ;
 _/nexus https://nexus.bu.edu/ ;
-_/niteo https://cpr.bu.edu/cmhp/ ;
+_/niteo https://www.bu.edu/psych-rehab/training-services/individuals-families/college-mental-health-education-programs/ ;
 _/november26 https://give.bu.edu/bu-main-giving-form/?a=10546815 ;
 _/november26camed https://give.bu.edu/chobanian-avedisian-som-giving-form/?a=10546815 ;
 _/november26cas https://give.bu.edu/cas-online-giving-form/?a=10546815 ;


### PR DESCRIPTION
Updated WebRouter niteo marketing URL mapping (approved by Jon B) to bypass broken legacy cmhp/cmhep redirect chain and wildcard overrides, ensuring direct resolution to the intended destination url.