### PR TITLE
DFCT2002360 Route common 404 URLs to static-public

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -184,6 +184,8 @@ _/admissions/applicantlink static-public ;
 _/admissions/presenter static-protected ;
 _/admissions/telegraph static-public ;
 _/admissionsstatic static-public ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/ads.txt static-public ;
 _/advocates redirect_asis ;
 _/aeacus static-public ;
 _/aegdalumnidinner redirect_asis ;
@@ -225,6 +227,8 @@ _/aparc redirect_asis ;
 _/apc redirect_asis ;
 _/apfd redirect_asis ;
 _/aphasia redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/api/v1 static-public ;
 _/apple-touch-icon-120x120-precomposed.png static-public ;
 _/apple-touch-icon-120x120.png static-public ;
 _/apple-touch-icon-152x152-precomposed.png static-public ;
@@ -249,6 +253,8 @@ _/archives redirect_asis ;
 _/armyrotc redirect_asis ;
 _/ars redirect_asis ;
 _/art redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/arts/calendar static-public ;
 _/artsnow redirect_asis ;
 _/ascend redirect_asis ;
 _/asllrp static-public ;
@@ -585,6 +591,8 @@ _/culinaryarts redirect_asis ;
 _/cwc redirect_asis ;
 _/cye24 redirect_asis ;
 _/cye25 redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/d2l/api static-public ;
 _/danrather redirect_asis ;
 _/dar-talent redirect_asis ;
 _/daratlas redirect_asis ;
@@ -673,6 +681,8 @@ _/euforyou redirect_asis ;
 _/eufutures redirect_asis ;
 _/events redirect_asis ;
 _/evergreen redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/ews/exchange.asmx static-public ;
 _/exchange redirect_asis ;
 _/exec redirect_asis ;
 _/execed redirect_asis ;
@@ -907,6 +917,8 @@ _/international redirect_asis ;
 _/internships redirect_asis ; ### reserved for Emma Bonanomi/Provost see INC20636359 ###
 _/intracghd redirect_asis ;
 _/investinprevention redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/ip static-public ;
 _/irwa redirect_asis ;
 _/ise redirect_asis ;
 _/isec redirect_asis ;
@@ -1074,6 +1086,8 @@ _/met/shared static-public ;
 _/met24 redirect_asis ;
 _/met25 redirect_asis ;
 _/met26 redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/meta.json static-public ;
 _/mickswan static-public ;
 _/mih static-public ;
 _/military redirect_asis ;
@@ -1121,6 +1135,8 @@ _/neurophotonics-nrt redirect_asis ;
 _/new2bu static-public ;
 _/newmedia static-public ;
 _/nexus redirect_asis ;
+# This is a common 404 page; routing away from WordPress for efficiency:
+_/nis/lib static-public ;
 _/niteo redirect_asis ;
 _/nitrides static-public ;
 _/no-boundaries static-public ;


### PR DESCRIPTION
Routes eight high-volume dead URLs to the `static-public` backend. Each still returns 404 — it now comes from S3 rather than a full WordPress page render.

DFCT2002360.

## Why

`WebTransaction/Action/404` is a complete page render that happens to return a 404 status, not a cheap error path. On www.bu.edu it runs **152,059 requests/day at 0.321s and 120 database queries each** (New Relic account 637623, measured 2026-08-17) — roughly 13.5 hours of PHP worker time per day.

The eight URLs below account for **20,454 requests/day**, about 13.5% of that volume.

Same mechanism as `fc2804a3` and `7f22b7a4` in `webrouter-prod`, including the comment convention.

## Entries

| Key | Serves | Requests/day |
|---|---|---|
| `_/arts/calendar` | `/arts/calendar/` | 13,458 |
| `_/meta.json` | `/meta.json` | 2,984 |
| `_/ews/exchange.asmx` | `/EWS/Exchange.asmx` and `/ews/exchange.asmx` | 1,169 |
| `_/api/v1` | `/api/v1/courses` | 937 |
| `_/d2l/api` | `/d2l/api/lp/1.0/enrollments/myenrollments/` | 913 |
| `_/nis/lib` | `/nis/lib/jquery/crossslide.js` | 421 |
| `_/ads.txt` | `/ads.txt` | 338 |
| `_/ip` | `/ip` | 234 |

`/EWS/` and `/ews/` need only the one lowercase key: the sites.map lookup is case-insensitive, confirmed against existing entries (`/ALERT/includes/x.js` and `/LINK` both resolve to `static-public`).

`/arts/calendar/` became a WordPress 404 when `_/arts redirect ;` was removed in `19258eb4` (RITM2082156, 2025-11-14). Restoring that redirect is not the fix — the `redirect` backend appends the request URI, so `/arts/calendar/` would 302 to `/cfa/arts/calendar/`, which does not exist.

## `_/alert/css` is deliberately not included

`/alert/css/alert.css` is the next-largest candidate at 4,919 requests/day, and the file does exist in the static-public bucket, so routing the prefix would serve it rather than 404 it.

It is excluded because the bucket prefix holds additional content that is not appropriate to publish under www.bu.edu. Those paths return 404 from WordPress today, and routing the prefix would expose them. This is tracked separately through IS&T's internal channel; the details are deliberately not recorded here.

Once the prefix has been cleaned up, `_/alert/css` is worth adding — it would restore a working stylesheet for those 4,919 requests/day rather than making their failure cheaper. The file is absent from the test and syst buckets, so no nonprod landscape demonstrates that behaviour.

## Verification

Built and run through the CodeBuild command (`buildspec.yml`): `docker build` then `run-nginx.sh -t` — `configuration file /etc/nginx/nginx.conf test is successful`.

Routing was compared against an unmodified image built from `origin/devl` (`56e373c`), querying every key in the map through `/server/lookup/`. Changed decisions only, nothing else moved:

- The eight keys resolve to `static-public`.
- `/nis/lib` and `/nis/lib/x` resolve to `static-public`. Prod has no `_/nis`, `_/api`, `_/arts`, `_/ip`, `_/ads`, `_/meta`, `_/d2l` or `_/ews` parent key, so all eight are clean additions with no precedence interactions.
- Unchanged: `/alert/css`, `/alert/includes/x`, `/met/events`, `/arts`, `/admissions`, `/admissions/wp-content`, `/nis`, `/api`, `/ipl`, `/advocates`, `/robots.txt`, `/apple-touch-icon.png`, `/link`, `/met26`.

Prefix audit of `static-sites-prod-public`: `nis/lib/`, `d2l/api/`, `api/v1/`, `arts/calendar`, `ip`, `ews`, `ads.txt` and `meta.json` hold no objects, so every request under them returns `NoSuchKey`. Each key is a prefix, so an object under one would be served rather than 404'd.

Post-deploy check: `verify-dfct2002360.sh <host>` asserts each key answers 404 from `static-public`, that the `/alert/css/` prefix keeps answering from WordPress, and that live pages still render.

## Scope

`/admissions/wp-content/themes/flexi-admissions/images/bu-logo.gif` (13,240/day) and the `/met/…/:/ ` family (12,266/day across 955 URIs) cannot be expressed in sites.map. The lookup keys on at most two path segments (`conf.d-map-def.conf`), and the segment charset excludes `:`. Both are tracked separately.


Note for anyone scripting edits to this repo: `maps/*.map` here use CRLF line endings, unlike `webrouter-nonprod` which uses LF. A tool that normalises them rewrites every line of the diff.
