### PR TITLE
DFCT2002360 Route /alert/css to static-public

### DIFF
--- a/maps/sites.map
+++ b/maps/sites.map
@@ -203,6 +203,8 @@ _/ai redirect_asis ;
 _/aias redirect_asis ;
 _/alcoholeducationforyouth static-public ;
 _/aldolase static-public ;
+# Restores the BU alert stylesheet from S3; was a WordPress 404 at ~4,900/day:
+_/alert/css static-public ;
 # This is a common 404 page; routing away from WordPress for efficiency:
 _/alert/includes static-public ; 
 _/alex redirect_asis ;


### PR DESCRIPTION
Routes `/alert/css` to the `static-public` S3 backend. Unlike the eight keys added in #1143, this entry serves a real file rather than a faster 404.

DFCT2002360.

## Why

`alert.css` exists in `static-sites-prod-public` at 3,097 bytes and is a documented dependency. The README stored alongside it records these files as *"deployed to bu.edu/alert/css and used in all BU Alert implementations … referenced by the phpbin application, WordPress plugin and other alert implementations such as the BU homepage"*.

The URL currently returns a WordPress 404 at **4,919 requests/day**, every one of them against `alert.css`. The requesters are ordinary browsers — Chrome 140–151 across Windows, macOS and Linux, iPhone Safari, Edge, Android — plus Applebot and a synthetic monitoring agent. Routing the prefix serves them the stylesheet and removes the requests from WordPress.

This entry was deferred from #1143. The issue that blocked it was resolved on 2026-08-19.

## The comment deliberately departs from convention

Every other routed entry carries *"This is a common 404 page; routing away from WordPress for efficiency."* That would be inaccurate here, because this entry produces a **200**.

## Verification

Built the image and ran CodeBuild's own gate (`run-nginx.sh -t`) — `configuration file test is successful`.

Routing confirmed in the built image through `/server/lookup/`:

| Path | Backend |
|---|---|
| `/alert/css`, `/alert/css/alert.css` | `static-public` |
| `/alert`, `/alert/foo` | `wordpress` — unchanged, parent not captured |
| `/alert/includes`, `/arts/calendar`, `/meta.json` | unchanged |

Prefix contents were enumerated before routing: `alert.css` is the only path receiving traffic. `style.css`, `errors.css`, `handheld.css`, `README.md` and `package-lock.json` are present but unrequested, and nothing else exists under the prefix.

Same shape as `_/alert/includes`, already live in prod.

Expected after deploy: `https://www.bu.edu/alert/css/alert.css` returns 200 `text/css`, 3,097 B, `X-Upstream: static-public`.

Note for anyone scripting edits to this repo: `maps/*.map` use CRLF line endings, unlike `webrouter-nonprod` which uses LF. A tool that normalises them rewrites every line of the diff.
